### PR TITLE
Properly import mask.png and workaround --outfile issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "email": "code@qrivi.dev"
   },
   "scripts": {
-    "build": "rm -rf ./build; bun build ./src/cli.ts --compile --minify --outfile ./build/macicon && find . -name \"*.bun-build\" -delete",
+    "clean": "rm -rf ./build",
+    "build": "bun build ./src/cli.ts --compile --minify && mkdir -p build && mv ./src/cli ./build/macicon",
     "check": "biome check ./src",
     "check:apply": "biome check --apply ./src"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,5 @@
 #! /usr/bin/env bun
 
-import os from "node:os";
 import { $ } from "bun";
 import { program } from "commander";
 import { description, name, version } from "../package.json";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import { $ } from "bun";
 import Jimp from "jimp";
+import maskPath from "../assets/mask.png";
 import { ITunesSearchResponse, type IconMode } from "./types";
 
 interface CleanAppPathArgs {
@@ -100,7 +101,7 @@ export const generateCustomIcon = async (args: GenerateCustomIconArgs) => {
       const imageSize = (iconSize - iconPadding * 2) * scale; // Size of the image inside the icon
       const imagePosition = (iconSize - imageSize) / 2 - iconPadding; // Offset to center image inside the icon
 
-      const maskBuffer = await Bun.file("assets/mask.png").arrayBuffer();
+      const maskBuffer = await Bun.file(maskPath).arrayBuffer();
       const imageBuffer = await Bun.file(pngPath).arrayBuffer();
       const mask = await Jimp.read(Buffer.from(maskBuffer));
       const image = await Jimp.read(Buffer.from(imageBuffer));


### PR DESCRIPTION
This should be a fix for #1.

According to [the docs](https://bun.sh/docs/bundler/executables#embedding-files), I needed to import `mask.png` in code for it to be embedded in the final binary.  I remember I skipped this before because it would break `bun run build` (would just complete but build nothing). This seems to be another issue with Bun: if the `--outfile` is set, building seems to do some things, but no bundled binary is created.

As a workaround I updated the scripts to manually create the `build` dir and move the executable after the build completes.